### PR TITLE
Workaround for missing assertion in `dbus.go`

### DIFF
--- a/99.patch
+++ b/99.patch
@@ -1,0 +1,36 @@
+From c6a3034bf0f22c1bff84f9ab7ac998456deb728b Mon Sep 17 00:00:00 2001
+From: Joe Gregorio <jcgregorio@google.com>
+Date: Wed, 29 Jul 2015 13:35:42 -0400
+Subject: [PATCH] Fix breakage from godbus changing *dbus.Object to
+ dbus.BusObject interface.
+
+---
+ dbus/dbus.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/dbus/dbus.go b/dbus/dbus.go
+index a7e72c2..5dd748e 100644
+--- a/dbus/dbus.go
++++ b/dbus/dbus.go
+@@ -64,11 +64,11 @@ func PathBusEscape(path string) string {
+ type Conn struct {
+ 	// sysconn/sysobj are only used to call dbus methods
+ 	sysconn *dbus.Conn
+-	sysobj  *dbus.Object
++	sysobj  dbus.BusObject
+ 
+ 	// sigconn/sigobj are only used to receive dbus signals
+ 	sigconn *dbus.Conn
+-	sigobj  *dbus.Object
++	sigobj  dbus.BusObject
+ 
+ 	jobListener struct {
+ 		jobs map[dbus.ObjectPath]chan<- string
+@@ -182,6 +182,6 @@ func dbusAuthHelloConnection(createBus func() (*dbus.Conn, error)) (*dbus.Conn,
+ 	return conn, nil
+ }
+ 
+-func systemdObject(conn *dbus.Conn) *dbus.Object {
++func systemdObject(conn *dbus.Conn) dbus.BusObject {
+ 	return conn.Object("org.freedesktop.systemd1", dbus.ObjectPath("/org/freedesktop/systemd1"))
+ }

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -5,4 +5,4 @@ SRC_PATH=$(pwd)
 
 # we're calling docker from within a container with a path (/data/jenkins) mounted into this container (/var/jenkins)
 # so the newly created container needs a different path (/data/jenkins).
-docker run --rm -v /data${SRC_PATH#/var}:/usr/src/sproxy -w /usr/src/sproxy golang:1.4 /bin/bash -c 'go get -d && go build -v'
+docker run --rm --volume=/data${SRC_PATH#/var}:/usr/src/sproxy --workdir=/usr/src/sproxy golang:1.4 /usr/src/sproxy/patch_dbus.sh

--- a/patch_dbus.sh
+++ b/patch_dbus.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# get all dependencies
+go get -d
+
+# test the build
+go build -v >/dev/stderr | true
+if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
+    exit 0
+fi
+
+# yeah, no patch...
+apt-get update
+apt-get install -y patch
+# an unsuccessfull build might be caused by the dbus assertion bug
+# so we patch it w/ pull request #99 and then try again.
+# pull request: https://github.com/coreos/go-systemd/issues/98
+filename=$(go build -v 2>&1 | awk -F ':' '/dbus.go/ {print $1}')
+echo "Filemname: ${filename}"
+hash=$(md5sum ${filename}|awk '{print $1}')
+echo "Hash: ${hash}"
+if [[ ${hash} == 3b75aae9d8a95a39d84b4c2160d938a2 ]]; then
+    cp 99.patch $(dirname ${filename})
+    cd $(dirname ${filename})
+    patch -p 1 dbus.go < 99.patch
+    cd -
+    go build -v
+fi
+


### PR DESCRIPTION
Makes the build proceed for now and can easily be reverted later as it only touches the build system.
